### PR TITLE
Fix bug where customer has a active order and user tries to delete this customer

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,7 +101,6 @@ Format: `edit m/MENU_ID [pn/PRODUCT_NAME] [pc/PRODUCT_COSTS] [ps/PRODUCT_SALES]`
 * Existing values will be updated to the input values.
 
 > [!NOTE]
-> 
 > Editing a product on the menu will not update the products on existing orders.
 
 Example:

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -41,6 +41,7 @@ public class Messages {
 
     public static final String MESSAGE_COEXISTING_CUSTOMER_AND_ORDER =
             "Customer ID and order ID cannot coexist here.";
+    public static final String MESSAGE_CUSTOMER_HAS_ORDER = "Customer has active order and cannot be removed.";
 
     public static final String MESSAGE_SPECIFY_EDIT = "Please follow up with either "
             + PREFIX_CUSTOMER_ID + "INDEX (for customer index)"

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerCommand.java
@@ -40,6 +40,9 @@ public class DeleteCustomerCommand extends DeleteCommand {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (personToDelete.getOrders().size() != 0) {
+            throw new CommandException(Messages.MESSAGE_CUSTOMER_HAS_ORDER);
+        }
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -164,6 +164,7 @@ public interface Model {
     Optional<Person> findPersonByPhoneNumber(String phoneNumber);
 
     Order findOrderByIndex(int id);
+
     /**
      * Returns an unmodifiable view of the filtered person list.
      *

--- a/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCustomerCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithPersonsOnly;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +25,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteCustomerCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBookWithPersonsOnly(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -87,6 +87,17 @@ public class TypicalPersons {
         return ab;
     }
 
+    public static AddressBook getTypicalAddressBookWithPersonsOnly() {
+        AddressBook ab = new AddressBook();
+        ArrayList<Person> typicalPersons = new ArrayList<>();
+        for (Person person : getTypicalPersons()) {
+            Person copy = new PersonBuilder(person).build();
+            ab.addPerson(copy);
+            typicalPersons.add(copy);
+        }
+        return ab;
+    }
+
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }


### PR DESCRIPTION
Fixed a bug where customer that has an active order, and user tries to delete this customer will result in a runtime exception. This results in the user action being failed silently and causes a crash. Thus, this bug  is okay to fix for v1.4